### PR TITLE
Feature/web setup

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -12,6 +12,7 @@
     "com.unity.test-framework": "1.4.5",
     "com.unity.timeline": "1.8.7",
     "com.unity.ugui": "2.0.0",
+    "com.unity.visualeffectgraph": "17.0.3",
     "com.unity.visualscripting": "1.9.5",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -233,6 +233,15 @@
         "com.unity.modules.imgui": "1.0.0"
       }
     },
+    "com.unity.visualeffectgraph": {
+      "version": "17.0.3",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.shadergraph": "17.0.3",
+        "com.unity.render-pipelines.core": "17.0.3"
+      }
+    },
     "com.unity.visualscripting": {
       "version": "1.9.5",
       "depth": 0,

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95e40a6771da94aa152f9607ac2fb3930c541e761c18b1cf3feb946a18a649e1
-size 24912
+oid sha256:4b037652923c8ec78c2327e67e4eaf760db59ae803f3e63ef7bd3762dca53a72
+size 25204

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6814d6cc3eb850dd7d2a069a8b17ba9f7591deba8b1758a855978bd9c8627643
-size 3662
+oid sha256:09d0917de6fac43216fa9b280534efeb5fc250f95b038533154e4e6287309f3b
+size 3666

--- a/ProjectSettings/ShaderGraphSettings.asset
+++ b/ProjectSettings/ShaderGraphSettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6779cfc151b3808da168141613d9a8dfb247592a2493cbcbf30e5c119a43cc14
-size 1007
+oid sha256:773803237466ffe9bbfed9ecef9bbe25f63196dd47ab6b3003f0cd1649fd2bd0
+size 524


### PR DESCRIPTION
- Enabled WebGPU
- Set default web player to WebGPU. Still falling back on WebGL, but this could cause Firefox/Safari users to have a subpar experience as they need to enable WebGPU via a developer flag (Would error when playing if we didn't fall back on WebGL)
- Set the default build settings for web to the PC settings (on the default (mobile settings) we don't have access to some rendering features we will need). We might need to tweak these settings later if they are too intensive for some players.